### PR TITLE
Set_parameters and get_options

### DIFF
--- a/libpyvinyl/BaseCalculator.py
+++ b/libpyvinyl/BaseCalculator.py
@@ -163,10 +163,10 @@ class BaseCalculator(AbstractBaseClass):
 
     @parameters.setter
     def parameters(self, value: CalculatorParameters):
-        self.set_parameters(value)
+        self.reset_parameters(value)
 
-    def set_parameters(self, value: CalculatorParameters):
-        """Set the calculator parameters"""
+    def reset_parameters(self, value: CalculatorParameters):
+        """Resets the calculator parameters"""
         if isinstance(value, CalculatorParameters):
             self.__parameters = value
         elif value is None:
@@ -175,6 +175,18 @@ class BaseCalculator(AbstractBaseClass):
             raise TypeError(
                 f"Calculator: `parameters` is expected to be CalculatorParameters, not {type(value)}"
             )
+
+    def set_parameters(self, args_as_dict=None, **kwargs):
+        """
+        Sets parameters contained in this calculator using dict or kwargs
+        """
+        if args_as_dict is not None:
+            parameter_dict = args_as_dict
+        else:
+            parameter_dict = kwargs
+
+        for key, parameter_value in parameter_dict.items():
+            self.parameters[key].value = parameter_value
 
     @property
     def instrument_base_dir(self) -> str:

--- a/libpyvinyl/Parameters/Parameter.py
+++ b/libpyvinyl/Parameters/Parameter.py
@@ -345,6 +345,12 @@ class Parameter(AbstractBaseClass):
     def get_options_are_legal(self):
         return self.__options_are_legal
 
+    def get_intervals(self):
+        return self.__intervals
+
+    def get_intervals_are_legal(self):
+        return self.__intervals_are_legal
+
     def is_legal(self, values=None):
         """
         Checks whether or not given or contained value is legal given constraints.

--- a/libpyvinyl/Parameters/Parameter.py
+++ b/libpyvinyl/Parameters/Parameter.py
@@ -339,6 +339,12 @@ class Parameter(AbstractBaseClass):
                     + " is now illegal based on the newly added option"
                 )
 
+    def get_options(self):
+        return self.__options
+
+    def get_options_are_legal(self):
+        return self.__options_are_legal
+
     def is_legal(self, values=None):
         """
         Checks whether or not given or contained value is legal given constraints.

--- a/tests/unit/test_BaseCalculator.py
+++ b/tests/unit/test_BaseCalculator.py
@@ -276,6 +276,18 @@ class BaseCalculatorTest(unittest.TestCase):
         calculator.parameters["plus_times"] = 5
         self.assertEqual(calculator.parameters["plus_times"].value, 5)
 
+    def test_set_param_values_with_set_parameters(self):
+        calculator = self.__default_calculator
+
+        calculator.set_parameters(plus_times=7)
+        self.assertEqual(calculator.parameters["plus_times"].value, 7)
+
+    def test_set_param_values_with_set_parameters_with_dict(self):
+        calculator = self.__default_calculator
+
+        calculator.set_parameters({"plus_times": 9})
+        self.assertEqual(calculator.parameters["plus_times"].value, 9)
+
     def test_collection_get_data(self):
         calculator = self.__default_calculator
         print(calculator.input)

--- a/tests/unit/test_Parameters.py
+++ b/tests/unit/test_Parameters.py
@@ -361,6 +361,20 @@ class Test_Parameter(unittest.TestCase):
         self.assertTrue(par.is_legal([3.1, 4.2, 4.4]))
         self.assertTrue(par.is_legal([3.1, 4.2, 4.4, 7]))
 
+    def test_get_intervals(self):
+        par = Parameter("test")
+        par.add_interval(3, 4.5, True)
+        par.add_interval(8, 10, True)
+
+        retrived_intervals = par.get_intervals()
+        self.assertEqual(len(retrived_intervals), 2)
+        self.assertEqual(retrived_intervals[0][0], 3)
+        self.assertEqual(retrived_intervals[0][1], 4.5)
+        self.assertEqual(retrived_intervals[1][0], 8)
+        self.assertEqual(retrived_intervals[1][1], 10)
+
+        self.assertTrue(par.get_intervals_are_legal())
+
     def test_parameters_with_quantity(self):
         """Test if we can construct and use a Parameter instance passing  pint.Quantity and pint.Unit objects to the constructor and interval setter."""
 

--- a/tests/unit/test_Parameters.py
+++ b/tests/unit/test_Parameters.py
@@ -259,6 +259,23 @@ class Test_Parameter(unittest.TestCase):
         self.assertTrue(par.is_legal(10.0))
         self.assertTrue(par.is_legal(11.0))
 
+    # case 2: illegal interval + illegal option
+    def test_parameter_get_options(self):
+        """
+        Ensure get_options returns the options as required
+        """
+        par = Parameter("test")
+        par.add_interval(None, 8.5, False)  # minus infinite to 8.5
+        par.add_option(5, True)  # this is stupid, already accounted in the interval
+        par.add_option(11, True)
+
+        retrieved_options = par.get_options()
+
+        self.assertEqual(len(retrieved_options), 2)
+        self.assertEqual(retrieved_options[0], 5.0)
+        self.assertEqual(retrieved_options[1], 11.0)
+        self.assertTrue(par.get_options_are_legal())
+
     def test_parameter_value_type(self):
         par = Parameter("test")
         par.value = 4.0


### PR DESCRIPTION
Discussed quick changes to libpyvinyl.

**BaseCalculator**
The former set_parameters replaced the entire parameters object, so it was renamed reset_parameters.

A new set_parameters now sets specified parameters in the calculator with nice syntax.

**Parameter**
Added getters for options and intervals as they are now obfuscated with double underscores.


Tests added for the new features in both BaseCalculator and Parameter.

As this is a hot fix it is going straight to master. May need new version number before merging.