### PR TITLE
Fix issue assigning incompatible values to a parameter

### DIFF
--- a/libpyvinyl/Parameters/Parameter.py
+++ b/libpyvinyl/Parameters/Parameter.py
@@ -209,7 +209,7 @@ class Parameter(AbstractBaseClass):
         """
 
         vtype = type(value)
-        assert vtype != None
+        assert vtype is not None
         v = value
         # First case: value is a list, it might be good to double check
         # that all the members are of the same type
@@ -243,10 +243,16 @@ class Parameter(AbstractBaseClass):
         :type value: str | boolean | int | float | object | pint.Quantity
         If value is a float, it is internally converted to a pint.Quantity
         """
+        if (
+            self.__unit is not None
+            and isinstance(value, pint.Quantity)
+            and value.check(self.__unit) is False
+        ):
+            raise pint.errors.DimensionalityError(value.units, self.__unit)
+
         self.__check_compatibility(value)
         self.__set_value_type(value)
         value = self.__to_quantity(value)
-
         if self.is_legal(value):
             self.__value = value
         else:

--- a/tests/unit/test_Parameters.py
+++ b/tests/unit/test_Parameters.py
@@ -127,6 +127,15 @@ class Test_Parameter(unittest.TestCase):
         with pytest.raises(TypeError):
             par.add_option(True, True)
 
+    def test_values_different_units(self):
+        par = Parameter("energy", unit="meV", comment="Energy of emitted particles")
+        import pint
+
+        ureg = pint.UnitRegistry()
+        with pytest.raises(pint.errors.DimensionalityError):
+            thisunit = Unit("meter")
+            par.value = 5 * thisunit
+
     # case 1: only legal option
     def test_parameter_legal_option_float(self):
         par = Parameter("test")


### PR DESCRIPTION
Bug discovered and reported by Mads.
When the value of a parameter is set with a pint.Quantity, there is an additional check to verify that the units have the same dimensionality and hence compatible.
