### PR TITLE
Update doc/requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,11 +1,7 @@
-pint
-dill
-numpy
-scipy
-jsons
-h5py
+-r ../requirements/prod.txt
 sphinx
 nbsphinx
 recommonmark
 sphinx_rtd_theme
+sphinx_autodoc_typehints
 pandoc


### PR DESCRIPTION
Add sphinx_autodoc_typehints as dependency for building docs. This should fix documentation building on readthedocs.