### PR TITLE
Updated imports of Pint to remove pin

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -1,5 +1,9 @@
 # Contributing
 
+## Development requirement
+Check [requirements/dev.txt](requirements/dev.txt).
+Make sure the formatter package [black](https://black.readthedocs.io/en/stable/)>=24.3.
+
 ## How to test
 
 Minimally needed:
@@ -53,8 +57,9 @@ pytest tests/integration
 2. Develop into the newly created branch
 3. Create appropriate unit tests in [tests/unit/](https://github.com/PaNOSC-ViNYL/libpyvinyl/tree/master/tests/unit)
 4. Test current development as indicated in [Testing](https://github.com/PaNOSC-ViNYL/libpyvinyl#testing).
-5. `git rebase -i master` w.r.t. current master to include the latest updates and squashing commits to a minimum. See also [here](https://opensource.com/article/20/4/git-rebase-i).
-6. Push your `BRANCH` to the upstream repo: `git push -f upstream BRANCH`.
-7. Create a pull request (PR) to the `master` branch on the GitHub page.
-8. PR should be reviewed and approved and be passing all CI tests.
-9. If passing all tests, Choose `Rebase and merge` to merge the PR with no further squashing.
+5. Format the code with [black](https://black.readthedocs.io/en/stable/)>=24.3
+6. `git rebase -i master` w.r.t. current master to include the latest updates and squashing commits to a minimum. See also [here](https://opensource.com/article/20/4/git-rebase-i).
+7. Push your `BRANCH` to the upstream repo: `git push -f upstream BRANCH`.
+8. Create a pull request (PR) to the `master` branch on the GitHub page.
+9. PR should be reviewed and approved and be passing all CI tests.
+10. If passing all tests, Choose `Rebase and merge` to merge the PR with no further squashing.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Requires:
 ```
-python >= 3.6
+python >= 3.8
 ```
 
 Simulations provide invaluable insights to plan (before) and

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ pip install requirements.txt
 make html
 ```
 
+## Development guide
+Please find the development guide [here](DEVEL.md).
+
 ## Acknowledgement
 
 This project has received funding from the European Union's Horizon 2020 research and innovation programme under grant agreement No. 823852.

--- a/libpyvinyl/BaseData.py
+++ b/libpyvinyl/BaseData.py
@@ -1,4 +1,5 @@
 """ :module BaseData: Module hosts the BaseData class."""
+
 from typing import Union, Optional
 from abc import abstractmethod, ABCMeta
 from libpyvinyl.AbstractBaseClass import AbstractBaseClass

--- a/libpyvinyl/Parameters/Collections.py
+++ b/libpyvinyl/Parameters/Collections.py
@@ -6,8 +6,8 @@ import copy
 
 from libpyvinyl.AbstractBaseClass import AbstractBaseClass
 from .Parameter import Parameter
-from pint.quantity import Quantity
-from pint.unit import Unit, UnitsContainer
+from pint import Unit, Quantity
+from pint.util import UnitsContainer
 
 from typing import Union
 

--- a/libpyvinyl/Parameters/Parameter.py
+++ b/libpyvinyl/Parameters/Parameter.py
@@ -5,8 +5,8 @@ import math
 import numpy
 from libpyvinyl.AbstractBaseClass import AbstractBaseClass
 
-from pint.unit import Unit
-from pint.quantity import Quantity
+from pint import Unit
+from pint import Quantity
 import pint.errors
 
 # typing

--- a/libpyvinyl/__init__.py
+++ b/libpyvinyl/__init__.py
@@ -1,4 +1,5 @@
 """ :module: Exposes all user facing classes in the common libpyvinyl namespace"""
+
 __author__ = "Carsten Fortmann-Grote, Mads Bertelsen, Juncheng E, Shervin Nourbakhsh"
 __email__ = "carsten.grote@xfel.eu, juncheng.e@xfel.eu, Mads.Bertelsen@ess.eu, nourbakhsh@ill.fr"
 __version__ = "1.2.5"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-pint<=0.19.2
+pint
 dill<=0.3.5.1
 scipy
 jsons

--- a/tests/integration/plusminus/plusminus/BaseCalculator.py
+++ b/tests/integration/plusminus/plusminus/BaseCalculator.py
@@ -1,4 +1,5 @@
 """ :module BaseCalculator: Module hosts the BaseData class."""
+
 from abc import abstractmethod, ABCMeta
 from typing import Union
 from pathlib import Path

--- a/tests/unit/test_Parameters.py
+++ b/tests/unit/test_Parameters.py
@@ -3,8 +3,8 @@ import numpy
 import pytest
 import os
 import tempfile
-from pint.quantity import Quantity
-from pint.unit import Unit
+from pint import Quantity
+from pint import Unit
 from libpyvinyl.Parameters import Parameter
 from libpyvinyl.Parameters import CalculatorParameters
 from libpyvinyl.Parameters import InstrumentParameters


### PR DESCRIPTION
The pinned version of Pint 0.19.2 did not support newer versions of Numpy.

Updated the imports and code with newest version of Pint 0.24.3 and see no issues within the package. There could be some lack of coverage on the unit area, so requested Shervin as reviewer.

There are however downstream issues of using a modern numpy with SimEx-Lite, the error messages can be seen in the action that ran on this pull request. It seems it is just a change in name of a function.