### PR TITLE
Update of how requirements are found in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,7 @@
 from setuptools import setup, find_packages
-import sys
-
-with open("requirements/prod.txt") as requirements_file:
-    require = requirements_file.read()
-    requirements = require.split()
-
-import codecs
 import os.path
+import codecs
+import sys
 
 
 def read(rel_path):
@@ -23,6 +18,9 @@ def get_from_init(rel_path, field):
     else:
         raise RuntimeError("Unable to find " + field + " string.")
 
+
+require = read(os.path.join("requirements", "prod.txt"))
+requirements = require.split()
 
 initfile = "libpyvinyl/__init__.py"
 version = get_from_init(initfile, "__version__")


### PR DESCRIPTION
There was already a function for finding things using the relative path, included requirements in that.

Also updated a line in cfg as there was a warning when building, support will stop for dashed arguments this month.